### PR TITLE
fixed a case of message: 'PHP Notice: Trying to get property of non-obje...

### DIFF
--- a/includes/class-static_press.php
+++ b/includes/class-static_press.php
@@ -324,7 +324,7 @@ CREATE TABLE `{$this->url_table}` (
 			$this->fetch_last_id()
 			);
 		$result = $wpdb->get_row($sql);
-		if (!is_wp_error($result) && $result->ID) {
+		if (!is_null($result) && !is_wp_error($result) && $result->ID) {
 			$next_id = $this->fetch_last_id($result->ID);
 			return $result;
 		} else {


### PR DESCRIPTION
...ct in .../class-static_press.php on line 326'

My environment:
- Mac OS X 10.9.3
- MAMP/ Apache 2.2.26
- MAMP/ MySQL 5.5.34
- PHP 5.5.10
- WordPress ja 3.9.1
- StaticPress 0.4.3.4

What I found was:
- installed WordPress ja 3.9.1 without any customization
- installed StaticPress and do set-ups
- Clicking the 再構築 button followed by 605 lines of messages that showed URL fetched, then エラー！ message came up.
- in the PHP error log file found a message: 

```
[14-Jul-2014 06:36:31 UTC] PHP Notice:  Trying to get property of non-object in ***/wp-content/plugins/staticpress/includes/class-static_press.php on line 327
```

My fix:
I read the source code of class-static_press.php on line 327. I found the line is a bit fragile. The line 327 is not prepared for the case where the $result has null value. I think it is better to check out the null-ness of $result. So I changed the line 327 and tested it. Now it works for me.
