### PR TITLE
Undefined index type

### DIFF
--- a/includes/class-static_press.php
+++ b/includes/class-static_press.php
@@ -551,7 +551,7 @@ CREATE TABLE `{$this->url_table}` (
 				$url['enable'] = 0;
 			} else if (preg_match('#/wp-admin/$#i', $url['url'])) {
 				$url['enable'] = 0;
-			} else if ($url['type'] == 'static_file') {
+			} else if (isset($url['type']) && $url['type'] == 'static_file') {
 				$plugin_dir  = trailingslashit(str_replace(ABSPATH, '/', WP_PLUGIN_DIR));
 				$theme_dir   = trailingslashit(str_replace(ABSPATH, '/', WP_CONTENT_DIR) . '/themes');
 				$file_source = untrailingslashit(ABSPATH) . $url['url'];


### PR DESCRIPTION
My environment:
- Mac OS X 10.9.3
- MAMP/ Apache 2.2.26
- MAMP/ MySQL 5.5.34
- MAMP/ PHP 5.5.10
- WordPress ja 3.9.1
- StaticPress 0.4.3.4

What I found was:
- installed WordPress ja 3.9.1
- add my posts ant custome themes
- installed StaticPress
- Clicking the 再構築 button followed by immediate エラー！ message.
- in the PHP eeror log file found messages saying

```
[14-Jul-2014 07:36:17 UTC] PHP Notice:  Undefined index: type in /Users/kazuakimatsuhashi/git/WordPressBooksReader/stepup/src/wp/wp-content/plugins/staticpress/includes/class-static_press.php on line 554
```

My fix:
I read the source code of class-static_press.php on line 554. I found it a bit fragile. The line 554 assumes that the $url array must have 'type' property with some value. If $url misses 'type' property, even accidentally, the processing may fail. I think it is safer to check existence of 'type' property in the $url array before accessing it. So I changed the line 554 and tested. Now it works fine for me.
