### PR TITLE
escape javascript error when result does not contain static file.

### DIFF
--- a/includes/class-static_press_admin.php
+++ b/includes/class-static_press_admin.php
@@ -308,7 +308,8 @@ jQuery(function($){
 							ul.append('<li>' + file_count + ' : ' + this.static + '</li>');
 						}
 					});
-					$('html,body').animate({scrollTop: $('li:last-child', ul).offset().top},'slow');
+					if(ul.children().size() > 0)
+						$('html,body').animate({scrollTop: $('li:last-child', ul).offset().top},'slow');
 					if (response.final)
 						static_press_finalyze();
 					else


### PR DESCRIPTION
初回の`static_press_fetch()`実行時、`response.files`に`static`が`true`でない`file`しか含まれていない場合に`<li>`が追加されず、`$('li:last-child', ul)`が発見できずにスクロースに失敗し、jsの処理が止まってしまうことがありました。
